### PR TITLE
Improve vuln scanning

### DIFF
--- a/.github/actions/create-issue/entrypoint.py
+++ b/.github/actions/create-issue/entrypoint.py
@@ -95,10 +95,16 @@ def create_github_issue(
 
 
 def update_github_issue(
-    issue_number: int, vulnerability: dict, base_url: str, headers: dict, timestamp: str
+    issue_number: int,
+    vulnerability: dict,
+    base_url: str,
+    headers: dict,
+    timestamp: str,
+    assignees: str = "",
 ):
     """
-    Updates an existing GitHub issue by posting a comment with new scan results.
+    Updates an existing GitHub issue by posting a comment with new scan results
+    and replacing the assignee.
     """
     artifact_id = vulnerability["ArtifactID"]
     vulnerability_text = vulnerability.get("vulnerabilities", [])
@@ -121,6 +127,18 @@ def update_github_issue(
             f"- **Critical vulnerabilities**: {', '.join(critical) if critical else 'None'}"
         )
     }
+
+    # Update assignee on the issue (replaces existing assignees)
+    issue_url = f"{base_url}/{issue_number}"
+    patch_body = {"assignees": [assignees] if assignees else []}
+    r_patch = requests.patch(issue_url, headers=headers, json=patch_body)
+    if r_patch.ok:
+        print(f"Updated assignee on issue #{issue_number} for {artifact_id}")
+    else:
+        print(
+            f"Failed to update assignee on issue #{issue_number}. "
+            f"Status: {r_patch.status_code}. Response: {r_patch.text}"
+        )
 
     comment_url = f"{base_url}/{issue_number}/comments"
     r = requests.post(comment_url, headers=headers, json=comment_body)
@@ -201,7 +219,7 @@ def main():
             create_github_issue(vulnerability, url, headers, timestamp, labels, assignees)
         elif result["status"] == "exists":
             issue_number = result["issue_number"]
-            update_github_issue(issue_number, vulnerability, url, headers, timestamp)
+            update_github_issue(issue_number, vulnerability, url, headers, timestamp, assignees)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/generate-image-list.yml
+++ b/.github/workflows/generate-image-list.yml
@@ -19,7 +19,8 @@ jobs:
   generate-image-list:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
           token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
@@ -31,7 +32,8 @@ jobs:
           ref: ${{ inputs.vuln-scanning-ref }}
           path: .vuln-scanning
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/vuln-scanning.yml
+++ b/.github/workflows/vuln-scanning.yml
@@ -64,21 +64,47 @@ jobs:
         continue-on-error: true
         run: |
           ENV_FILE="${{ inputs.env-file-path }}"
-          IMAGES=$(grep "IMAGE" "$ENV_FILE" | cut -d '=' -f2)
-          # *** FIX IS HERE ***
-          SCAN_RESULTS_JSON="${{ inputs.scan-report }}" # Use the input variable
+          SCAN_RESULTS_JSON="${{ inputs.scan-report }}"
           echo "[]" > "$SCAN_RESULTS_JSON"
-          for IMAGE in $IMAGES; do
+
+          # Helper: run trivy on IMAGE, append result to SCAN_RESULTS_JSON,
+          # optionally override the ArtifactID in the JSON (for built images).
+          scan_image() {
+            local IMAGE="$1"
+            local ARTIFACT_ID="${2:-$IMAGE}"
             echo "Scanning $IMAGE..."
+            local FILENAME
             FILENAME=$(echo "$IMAGE" | sed 's/[\/:]/_/g')
-            SCAN_FILE="${FILENAME}-scan.json"
+            local SCAN_FILE="${FILENAME}-scan.json"
             trivy image --format json --scanners vuln --severity CRITICAL,HIGH "$IMAGE" > "$SCAN_FILE" || true
-            RESULT=$(jq '{
-              ArtifactID: .ArtifactName,
-              vulnerabilities: [(.Results[] | select(.Vulnerabilities != null) | .Vulnerabilities[] |{Title:.Title,VulnerabilityID: .VulnerabilityID, Severity: .Severity})]
+            local RESULT
+            RESULT=$(jq --arg id "$ARTIFACT_ID" '{
+              ArtifactID: $id,
+              vulnerabilities: [(.Results[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | {Title:.Title, VulnerabilityID:.VulnerabilityID, Severity:.Severity})]
             }' "$SCAN_FILE")
             jq --argjson new "$RESULT" '. + [$new]' "$SCAN_RESULTS_JSON" > tmp.json && mv tmp.json "$SCAN_RESULTS_JSON"
             rm "$SCAN_FILE"
+          }
+
+          # --- Scan pre-built images (*_IMAGE variables) ---
+          grep "_IMAGE=" "$ENV_FILE" | cut -d '=' -f2 | while read -r IMAGE; do
+            scan_image "$IMAGE"
+          done
+
+          # --- Build and scan GitHub build-context images (*_BUILD variables) ---
+          grep "_BUILD=" "$ENV_FILE" | while IFS= read -r LINE; do
+            VAR_NAME=$(echo "$LINE" | cut -d '=' -f1)
+            BUILD_URL=$(echo "$LINE" | cut -d '=' -f2-)
+            # Skip comment lines
+            [[ "$VAR_NAME" == \#* ]] && continue
+            # Derive a local image tag from the variable name:
+            # e.g. PLATFORM_OUTPUT_SUPPORT_DATA_LOADER_DOCKERIZED_BUILD
+            #   -> platform-output-support-data-loader-dockerized:local-scan
+            LOCAL_TAG=$(echo "$VAR_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/_build$//' | sed 's/_/-/g'):local-scan
+            echo "Building $BUILD_URL as $LOCAL_TAG ..."
+            docker build "$BUILD_URL" -t "$LOCAL_TAG"
+            scan_image "$LOCAL_TAG" "$BUILD_URL"
+            docker rmi "$LOCAL_TAG" || true
           done
       - name: Run Snyk to check for vulnerabilities
         if: env.SCANNER == 'snyk'
@@ -95,11 +121,30 @@ jobs:
           name: vuln-scan-results
           path: ${{ inputs.scan-report }}
 
+      - name: Resolve assignee from rotation
+        id: resolve-assignee
+        run: |
+          EXPLICIT_ASSIGNEE='${{ inputs.assignee-user }}'
+          if [ -n "$EXPLICIT_ASSIGNEE" ]; then
+            ASSIGNEE="$EXPLICIT_ASSIGNEE"
+          else
+            ROTATION='${{ vars.ROTATION_USERS }}'
+            if [ -n "$ROTATION" ] && [ "$ROTATION" != "null" ]; then
+              MONTH=$(date +%-m)
+              LENGTH=$(echo "$ROTATION" | jq 'length')
+              INDEX=$(( (MONTH - 1) % LENGTH ))
+              ASSIGNEE=$(echo "$ROTATION" | jq -r ".[$INDEX]")
+            else
+              ASSIGNEE=""
+            fi
+          fi
+          echo "assignee=$ASSIGNEE" >> $GITHUB_OUTPUT
+
       - name: Run Create GitHub Projects Ticket Action
         id: report-vulnerabilities
         uses: thehyve/vulnerability-scanning/.github/actions/create-issue@main
         with:
           token: ${{ secrets.token }}
-          assignee: ${{ inputs.assignee-user }}
+          assignee: ${{ steps.resolve-assignee.outputs.assignee }}
           tag: ${{ inputs.tag }}
           file-name: ${{ inputs.scan-report }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Reusable GitHub Actions workflows to scan Docker images for vulnerabilities and 
 - [Reusable workflows](#reusable-workflows)
   - [generate-image-list](#1-generate-image-list)
   - [vuln-scanning](#2-vuln-scanning)
+  - [Monthly assignee rotation](#monthly-assignee-rotation)
 - [scan_docker_images.py (local use)](#scan_docker_imagespy-local-use)
 - [Variable naming convention](#variable-naming-convention)
 - [Issue lifecycle](#issue-lifecycle)
@@ -26,18 +27,20 @@ This repository provides two independent reusable workflows:
 ┌─────────────────────────────────────────────┐
 │           generate-image-list               │
 │                                             │
-│  Compose files ─┐                           │
+│  Compose files ─┐  image: <ref>             │
 │  Dockerfiles    ├─ scan_docker_images.py ──►│──► docker_images.env
-│  *.yml / *.yaml─┘                           │    (committed to repo)
+│  *.yml / *.yaml─┘  build: <github-url>      │    (committed to repo)
 └─────────────────────────────────────────────┘
                           │
                           │  (or bring your own docker_images.env)
                           ▼
 ┌─────────────────────────────────────────────┐
 │              vuln-scanning                  │
-│                                             │
-│  docker_images.env ──► Trivy / Snyk scan ──►│──► GitHub Issues
-│                                             │    (HIGH / CRITICAL)
+│           (docker_images.env)               │
+│  *_IMAGE vars ──► trivy image <ref>         │
+│                                        ─────│──► GitHub Issues
+│  *_BUILD vars ──► docker build <url>        │    (HIGH / CRITICAL)
+│                   trivy image <local-tag>   │
 └─────────────────────────────────────────────┘
 ```
 
@@ -54,12 +57,23 @@ The workflows are designed to be used together or independently, depending on yo
 1. **Image discovery** (`generate-image-list` workflow)  
    `scan_docker_images.py` walks the caller's repository and finds every Docker image reference in:
    - `docker-compose.yml`, `*.yml`, `*.yaml` – lines matching `image: <ref>`
+   - `docker-compose.yml`, `*.yml`, `*.yaml` – `build: <github-url>` directives (string form and `context:` map form)
    - `Dockerfile`, `Dockerfile.*` – lines matching `FROM <ref>`
 
-   References that use environment-variable substitution (`${VAR}`) are skipped because they are already sourced from the `.env` file. The discovered images are written to `docker_images.env` (or a custom path) and committed back to the caller's repository.
+   Variable substitutions (`${VAR}`) are handled differently depending on the source:
+   - **`image: ${VAR}` in Compose files** — skipped, because the actual image name is already stored in the `.env` file (that's the convention this workflow is built around).
+   - **`FROM ${VAR}` in local and remote Dockerfiles** — the script attempts to resolve the variable using `ARG NAME=default` declarations in the same file. References that remain unresolvable after substitution are skipped.
+
+   The discovered images are written to `docker_images.env` (or a custom path) and committed back to the caller's repository.
+
+   For `build:` entries pointing at a public GitHub repository, the script also fetches the remote `Dockerfile` and extracts the `FROM` base images from it, so those base images are scanned too. The build URL itself is recorded as a `*_BUILD` variable so the `vuln-scanning` workflow can build and scan the resulting image.
 
 2. **Vulnerability scanning** (`vuln-scanning` workflow)  
-   Reads a `docker_images.env` file containing `*_IMAGE` variables (produced by step 1, or maintained manually), iterates over every image, and scans each one with either **Trivy** or **Snyk**. Results are saved as a JSON artifact.
+   Reads a `docker_images.env` file and scans every entry:
+   - **`*_IMAGE` variables** — the image is pulled and scanned directly with Trivy.
+   - **`*_BUILD` variables** — the GitHub build-context URL is passed to `docker build`, and the resulting local image is scanned with Trivy. The issue title uses the original build URL for traceability.
+
+   Results are saved as a JSON artifact.
 
 3. **Issue management** (`create-issue` action)  
    Compares the scan results against existing open GitHub Issues (filtered by a caller-supplied label). For each vulnerable image:
@@ -159,17 +173,49 @@ jobs:
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `scan-option` | Yes | `trivy` | Scanner to use: `trivy` or `snyk` |
-| `env-file-path` | Yes | | Path to the `.env` file containing `*_IMAGE` variables |
+| `env-file-path` | Yes | | Path to the `.env` file containing `*_IMAGE` and/or `*_BUILD` variables |
 | `tag` | Yes | | Label applied to all created GitHub Issues (used to correlate issues between runs) |
-| `assignee-user` | No | *(none)* | GitHub username to assign created issues to |
+| `assignee-user` | No | *(none)* | GitHub username to assign to created and updated issues. Takes precedence over `ROTATION_USERS` when set (see [Monthly assignee rotation](#monthly-assignee-rotation)) |
 | `scan-report` | No | `scan_result.json` | Path to write the raw scan output (JSON) |
 
 **Secrets:**
 
 | Secret | Required | Description |
 |---|---|---|
-| `token` | Yes | GitHub token used to create/update issues (typically `GITHUB_TOKEN`) |
+| `token` | Yes | GitHub token used to create/update issues (typically the built-in `GITHUB_TOKEN`) |
 | `snyk-token` | No | Snyk API token (required when `scan-option` is `snyk`) |
+
+---
+
+### 🔄 Monthly assignee rotation
+
+When the workflow runs on a schedule (e.g. monthly), you can automatically rotate issue assignees without changing any workflow code. Define a repository variable named `ROTATION_USERS` containing a JSON array of GitHub usernames:
+
+**Setup:**
+
+1. Go to your repository → **Settings → Secrets and variables → Actions → Variables tab**
+2. Click **New repository variable**
+3. Name: `ROTATION_USERS`
+4. Value: a JSON array of GitHub usernames, in the order you want them assigned:
+
+```json
+["alice", "bob", "carol", "dave"]
+```
+
+**How it works:**
+
+At runtime the workflow evaluates `(current_month - 1) % array_length` to select the assignee:
+
+| Month | Index (4-person example) | Assignee |
+|---|---|---|
+| January | 0 | `alice` |
+| February | 1 | `bob` |
+| March | 2 | `carol` |
+| April | 3 | `dave` |
+| May | 0 | `alice` (wraps around) |
+| … | … | … |
+
+If `assignee-user` is specified on the workflow call, it takes precedence over `ROTATION_USERS`. If neither is set, no assignee is applied.
 
 ---
 
@@ -187,13 +233,16 @@ OUTPUT_FILE=infra/images.env python3 scan_docker_images.py
 
 **What is scanned:**
 - `*.yml` / `*.yaml` – `image: <ref>` directives (YAML anchors are supported)
-- `Dockerfile` / `Dockerfile.*` – `FROM <ref>` directives (`scratch` and variable references are skipped)
+- `*.yml` / `*.yaml` – `build: <github-url>` directives (string form and `context:` map form); the remote `Dockerfile` is fetched and its `FROM` base images are extracted (with `ARG` default resolution). The build URL is also recorded as a `*_BUILD` entry.
+- `Dockerfile` / `Dockerfile.*` – `FROM <ref>` directives (`scratch` and unresolvable variable references are skipped; `ARG NAME=default` substitutions are resolved)
 
 **Skipped directories:** `.git`, `.mypy_cache`, `node_modules`, `__pycache__`, `.venv`
 
 ---
 
 ## 🏷️ Variable naming convention
+
+### `*_IMAGE` variables — pre-built images
 
 Given an image reference the script derives an environment-variable name as follows:
 
@@ -218,6 +267,35 @@ CLICKHOUSE_SERVER_25_8_2_29_IMAGE=clickhouse/clickhouse-server:25.8.2.29
 
 Version-prefix tags (e.g. `mysql:8` alongside `mysql:8.0`) are automatically merged — the shorter prefix is absorbed into the more specific tag.
 
+### `*_BUILD` variables — GitHub build-context images
+
+When a `build: <github-url>` directive is found, the build URL is recorded as a separate variable using the GitHub repo name and branch:
+
+| Step | Example |
+|---|---|
+| Original build URL | `https://github.com/thehyve/platform-output-support.git#rm/data-loader-dockerized` |
+| Repo name | `platform-output-support` |
+| Last branch segment | `data-loader-dockerized` |
+| Join, replace non-word chars with `_`, upper-case | `PLATFORM_OUTPUT_SUPPORT_DATA_LOADER_DOCKERIZED` |
+| Append `_BUILD` | `PLATFORM_OUTPUT_SUPPORT_DATA_LOADER_DOCKERIZED_BUILD` |
+
+Example env file with both types:
+
+```env
+# Found in: docker-compose.yml
+PLATFORM_OUTPUT_SUPPORT_DATA_LOADER_DOCKERIZED_BUILD=https://github.com/thehyve/platform-output-support.git#rm/data-loader-dockerized
+
+# Found in: docker-compose.yml → https://raw.githubusercontent.com/thehyve/platform-output-support/rm/data-loader-dockerized/Dockerfile
+PYTHON_IMAGE=python:3.13-slim
+
+# Found in: docker-compose.yml
+REDIS_IMAGE=redis:7
+```
+
+The `vuln-scanning` workflow handles both types automatically:
+- `*_IMAGE` → pulled and scanned with `trivy image`
+- `*_BUILD` → built with `docker build <url>` then scanned with `trivy image`
+
 ---
 
 ## 🎫 Issue lifecycle
@@ -225,7 +303,7 @@ Version-prefix tags (e.g. `mysql:8` alongside `mysql:8.0`) are automatically mer
 | Condition | Action |
 |---|---|
 | 🆕 Vulnerability found, no existing issue | New issue created with `HIGH` / `CRITICAL` label(s) and CVE list |
-| 🔄 Vulnerability found, issue already exists | Comment added to the existing issue with updated scan timestamp and CVE list |
+| 🔄 Vulnerability found, issue already exists | Assignee replaced with the current assignee, and a comment added with updated scan timestamp and CVE list |
 | ✅ No HIGH or CRITICAL vulnerabilities for an image | No issue created or updated |
 
 Issues are matched by title (`Vulnerability detected in <image>`) and the caller-supplied `tag` label, so scans from different projects do not interfere with each other.

--- a/scan_docker_images.py
+++ b/scan_docker_images.py
@@ -25,9 +25,12 @@ Given an image reference like  ghcr.io/opentargets/platform-api:25.4.2
 Output is sorted alphabetically by variable name.
 """
 
+from __future__ import annotations
+
 import os
 import re
 import sys
+import urllib.request
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -96,6 +99,207 @@ def _derive_var_name(image_ref: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# GitHub build-context helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_github_build_url(url: str) -> tuple[str, str, str, str] | None:
+    """
+    Parse a Docker Compose build context URL pointing to a public GitHub repo.
+    Returns (owner, repo, branch, subdir) or None if not a recognised GitHub URL.
+
+    Docker supports:  https://github.com/owner/repo[.git][#branch[:subdir]]
+    """
+    m = re.match(
+        r"https://github\.com/([^/]+)/([^/#\s]+?)(?:\.git)?"
+        r"(?:#([^:\s]*)(?::([^\s]*))?)?$",
+        url,
+        re.IGNORECASE,
+    )
+    if not m:
+        return None
+    owner = m.group(1)
+    repo = m.group(2)
+    branch = m.group(3) or ""
+    subdir = (m.group(4) or "").strip("/")
+    return owner, repo, branch, subdir
+
+
+def _fetch_github_dockerfile(
+    build_url: str, dockerfile_name: str = "Dockerfile"
+) -> tuple[str, str] | None:
+    """
+    Fetch a Dockerfile from a GitHub build-context URL.
+    Returns (file_content, raw_url_used) or None on failure.
+
+    When no branch is encoded in the URL, tries ``main`` then ``master``.
+    """
+    parsed = _parse_github_build_url(build_url)
+    if parsed is None:
+        return None
+    owner, repo, branch, subdir = parsed
+
+    file_path = "/".join(p for p in [subdir, dockerfile_name] if p)
+    branches_to_try = [branch] if branch else ["main", "master"]
+
+    for b in branches_to_try:
+        raw_url = (
+            f"https://raw.githubusercontent.com/{owner}/{repo}/{b}/{file_path}"
+        )
+        try:
+            with urllib.request.urlopen(raw_url, timeout=15) as resp:  # noqa: S310
+                content = resp.read().decode("utf-8", errors="replace")
+            return content, raw_url
+        except Exception:
+            continue
+
+    print(
+        f"  Warning: could not fetch {dockerfile_name} from {build_url}",
+        file=sys.stderr,
+    )
+    return None
+
+
+def _derive_build_var_name(build_url: str) -> str:
+    """
+    Derive an env-var name for a GitHub build-context URL, ending with _BUILD.
+
+    e.g. https://github.com/thehyve/platform-output-support.git#rm/data-loader-dockerized
+         → PLATFORM_OUTPUT_SUPPORT_DATA_LOADER_DOCKERIZED_BUILD
+    """
+    parsed = _parse_github_build_url(build_url)
+    if parsed is None:
+        return re.sub(r"[^A-Za-z0-9]+", "_", build_url).strip("_").upper() + "_BUILD"
+    _, repo, branch, _ = parsed
+    # Include the last segment of the branch to keep entries from the same
+    # repo on different branches distinct.
+    parts = [repo, branch.split("/")[-1]] if branch else [repo]
+    full = "_".join(p for p in parts if p)
+    return re.sub(r"[^A-Za-z0-9]+", "_", full).strip("_").upper() + "_BUILD"
+
+
+_ARG_DEFAULT_RE = re.compile(r"^ARG\s+(\w+)=(\S+)", re.IGNORECASE)
+_ARG_VAR_RE = re.compile(r"\$\{?(\w+)\}?")
+# Like _FROM_RE but captures the full token including $ signs so that ARG-
+# substituted references (e.g. FROM ${BASE_IMAGE}) can be resolved.
+_FROM_RE_WITH_VARS = re.compile(r"^FROM\s+(\S+)", re.IGNORECASE)
+
+
+def _extract_from_refs(content: str) -> list[str]:
+    """
+    Parse a Dockerfile and return the resolved FROM image references.
+
+    ARG defaults (``ARG NAME=value``) are collected in order and substituted
+    into FROM references that use variable syntax (``FROM ${BASE_IMAGE}``).
+    References that still contain unresolvable variables after substitution are
+    skipped, as are ``scratch`` and static variable-free refs containing ``$``.
+    """
+    arg_defaults: dict[str, str] = {}
+    refs: list[str] = []
+
+    for line in content.splitlines():
+        # Collect ARG default values
+        m = _ARG_DEFAULT_RE.match(line)
+        if m:
+            arg_defaults[m.group(1)] = m.group(2).strip("\"'")
+            continue
+
+        m = _FROM_RE_WITH_VARS.match(line)
+        if not m:
+            continue
+
+        ref = m.group(1).strip()
+        if ref.lower() == "scratch":
+            continue
+
+        if "$" in ref:
+            # Substitute all ${VAR} / $VAR occurrences with known ARG defaults
+            def _subst(match: re.Match) -> str:
+                return arg_defaults.get(match.group(1), match.group(0))
+
+            resolved = _ARG_VAR_RE.sub(_subst, ref)
+            if "$" in resolved:
+                # Still has unresolvable variable — cannot determine image
+                continue
+            ref = resolved
+
+        refs.append(ref)
+
+    return refs
+
+
+def _scan_yaml_for_builds(text: str) -> list[tuple[str, str]]:
+    """
+    Scan YAML text for ``build:`` directives that reference a GitHub repository.
+
+    Handles the string form::
+
+        build: https://github.com/org/repo.git#branch
+
+    and the map form::
+
+        build:
+          context: https://github.com/org/repo.git#branch
+          dockerfile: Dockerfile.custom   # optional
+
+    Returns a list of ``(build_url, dockerfile_name)`` pairs.
+    """
+    results: list[tuple[str, str]] = []
+    in_build_block = False
+    build_indent = -1
+    context_url: str | None = None
+    dockerfile_name = "Dockerfile"
+
+    for raw in text.splitlines():
+        stripped = raw.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        indent = len(raw) - len(stripped)
+
+        if in_build_block:
+            if indent <= build_indent:
+                # Leaving the build block — save what we collected
+                if context_url:
+                    results.append((context_url, dockerfile_name))
+                in_build_block = False
+                context_url = None
+                dockerfile_name = "Dockerfile"
+                # Fall through to check this line as a new directive
+            else:
+                m = re.match(r"\s*context\s*:\s*(.+)", raw)
+                if m:
+                    val = m.group(1).strip().strip("\"'")
+                    if val.lower().startswith("https://github.com/"):
+                        context_url = val
+                m = re.match(r"\s*dockerfile\s*:\s*(\S+)", raw)
+                if m:
+                    dockerfile_name = m.group(1).strip().strip("\"'")
+                continue
+
+        # String form:  build: <url>
+        m = re.match(r"\s*build\s*:\s*(\S+)", raw)
+        if m:
+            val = m.group(1).strip().strip("\"'")
+            if val.lower().startswith("https://github.com/"):
+                results.append((val, "Dockerfile"))
+            continue
+
+        # Map form:  build:   (nothing after the colon)
+        if re.match(r"\s*build\s*:\s*$", raw):
+            in_build_block = True
+            build_indent = indent
+            context_url = None
+            dockerfile_name = "Dockerfile"
+
+    # EOF while still inside a build block
+    if in_build_block and context_url:
+        results.append((context_url, dockerfile_name))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Scanning
 # ---------------------------------------------------------------------------
 
@@ -130,6 +334,11 @@ def scan_repo(root: Path) -> tuple[dict[str, str], dict[str, list[str]]]:
     """
     all_refs: set[str] = set()
     ref_sources: dict[str, list[str]] = {}  # image_ref → list of relative file paths
+    # (build_url, dockerfile_name, rel_path_of_compose_file)
+    build_contexts: list[tuple[str, str, str]] = []
+    # GitHub build-context URLs kept separately because they are not pullable
+    # image refs; they go straight into the output dict as *_BUILD entries.
+    build_found: dict[str, str] = {}
 
     yaml_exts = {".yml", ".yaml"}
 
@@ -141,7 +350,8 @@ def scan_repo(root: Path) -> tuple[dict[str, str], dict[str, list[str]]]:
         rel = str(path.relative_to(root))
 
         if path.suffix.lower() in yaml_exts:
-            for line in path.read_text(errors="replace").splitlines():
+            text = path.read_text(errors="replace")
+            for line in text.splitlines():
                 m = _IMAGE_RE.match(line)
                 if m:
                     ref = m.group(1).strip().strip('"').strip("'")
@@ -153,22 +363,47 @@ def scan_repo(root: Path) -> tuple[dict[str, str], dict[str, list[str]]]:
                         and not re.match(r"Dockerfile(\.\S+)?$", ref, re.IGNORECASE)
                     ):
                         refs.append(ref)
+            # Collect GitHub build: contexts for remote Dockerfile fetching
+            for build_url, dockerfile_name in _scan_yaml_for_builds(text):
+                build_contexts.append((build_url, dockerfile_name, rel))
 
         elif path.name.lower() == "dockerfile" or path.name.lower().startswith(
             "dockerfile."
         ):
-            for line in path.read_text(errors="replace").splitlines():
-                m = _FROM_RE.match(line)
-                if m:
-                    ref = m.group(1).strip()
-                    if "$" not in ref and ref.lower() != "scratch":
-                        refs.append(ref)
+            refs.extend(_extract_from_refs(path.read_text(errors="replace")))
 
         for ref in refs:
             ref_sources.setdefault(ref, [])
             if rel not in ref_sources[ref]:
                 ref_sources[ref].append(rel)
         all_refs.update(refs)
+
+    # Fetch remote Dockerfiles referenced via build: GitHub URLs and extract
+    # their FROM base images so they are included in the vulnerability scan.
+    # Also add the build URL itself so the CI workflow can build and scan the
+    # resulting image with Trivy.
+    for build_url, dockerfile_name, source_file in build_contexts:
+        # Record the build URL so it appears in the output env file as a
+        # *_BUILD entry; the downstream workflow can use it to docker build +
+        # trivy scan the final image.
+        build_var = _derive_build_var_name(build_url)
+        build_found[build_var] = build_url
+        ref_sources.setdefault(build_url, [])
+        if source_file not in ref_sources[build_url]:
+            ref_sources[build_url].append(source_file)
+
+        # Fetch the Dockerfile and extract base images (resolving ARG defaults)
+        result = _fetch_github_dockerfile(build_url, dockerfile_name)
+        if result is None:
+            continue
+        content, raw_url = result
+        remote_source = f"{source_file} → {raw_url}"
+        print(f"  Fetched remote Dockerfile: {raw_url}", file=sys.stderr)
+        for ref in _extract_from_refs(content):
+            all_refs.add(ref)
+            ref_sources.setdefault(ref, [])
+            if remote_source not in ref_sources[ref]:
+                ref_sources[ref].append(remote_source)
 
     # Merge refs where one tag is a version-prefix of another for the same image
     # e.g. mysql:8  +  mysql:8.0  →  keep mysql:8.0, merge sources
@@ -218,6 +453,10 @@ def scan_repo(root: Path) -> tuple[dict[str, str], dict[str, list[str]]]:
             full = f"{name}_{tag}"
             new_var = re.sub(r"[^A-Za-z0-9]+", "_", full).strip("_").upper() + "_IMAGE"
             found[new_var] = ref
+
+    # Merge build-context entries (these bypass the image deduplication logic
+    # because they are build URLs, not pullable image refs).
+    found.update(build_found)
 
     return found, ref_sources
 


### PR DESCRIPTION
- option to cycle the github user that will be assigned to a ticket
- update assignee when updating a ticket (not only assigning a user when creating a ticket)
- scan for images build from public git repo
  - get base images as well as build the image locally before trivy vuln scanning

readme is updated